### PR TITLE
Remove deprecated polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "devDependencies": {
     "@babel/core": "^7.22.9",
     "@babel/helper-compilation-targets": "^7.22.9",
-    "@babel/polyfill": "^7.12.1",
     "@babel/preset-env": "^7.22.9",
     "babel-loader": "^8.2.5",
     "copy-webpack-plugin": "^9.1.0",

--- a/resources/js/bundle/highlight.js
+++ b/resources/js/bundle/highlight.js
@@ -1,6 +1,5 @@
 'use strict';
 
-import * as poly from "@babel/polyfill/dist/polyfill";
 import hljs from  "highlight.js/lib/core";
 import xml from "highlight.js/lib/languages/xml";
 import php from "highlight.js/lib/languages/php";


### PR DESCRIPTION
I don't think it was used at all.. At least the code highlighting is still working.
Closes #6 